### PR TITLE
chore: avoid repetitions

### DIFF
--- a/src/graphql/context.js
+++ b/src/graphql/context.js
@@ -1,0 +1,9 @@
+import fetch from 'node-fetch';
+
+const getUsers = (path = '') => fetch(`http://localhost:3000/users/${path}`);
+
+export const context = () => {
+  return {
+    getUsers,
+  };
+};

--- a/src/graphql/user/userResolvers.js
+++ b/src/graphql/user/userResolvers.js
@@ -2,10 +2,10 @@
 // no seu respectivo TypeDefs.
 // No exemplo abaixo podemos notar o argumento *id*, que foi passado para user(id: ID!): String!...
 // Desta forma o GQL consegue receber o id do usuário e passar para user quando fizer a requisição.
-const user = async (_, { id }, { fetch }) => {
-  const getUser = await fetch(`http://localhost:3000/users/${id}`);
+const user = async (_, { id }, { getUsers }) => {
+  const response = await getUsers(`/${id}`);
 
-  const user = await getUser.json();
+  const user = await response.json();
 
   return user;
 };
@@ -15,10 +15,10 @@ const user = async (_, { id }, { fetch }) => {
 // Exemplificando: context: () => { return { magic: "mágica"}}
 // O terceiro parâmetro da minha função compartilhará em todos os resolvers o mesmo valor 'mágica'.
 
-const users = async (_, __, { fetch }) => {
-  const getUsers = await fetch('http://localhost:3000/users/');
+const users = async (_, __, { getUsers }) => {
+  const response = await getUsers();
 
-  return getUsers.json();
+  return response.json();
 };
 
 export const userResolvers = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,13 @@
 import { ApolloServer } from 'apollo-server';
 import { typeDefs, resolvers } from './graphql/schemas,';
-import fetch from 'node-fetch';
+import { context } from './graphql/context';
 
 const server = new ApolloServer({
   typeDefs,
   resolvers,
   // através do context é possível compartilhar
   // a mesma função/objeto/dado dentre seus inúmeros resolvers.
-  context: () => {
-    return {
-      fetch,
-    };
-  },
+  context,
 });
 
 server.listen(4003).then(({ url }) => console.log(`Server listening ${url}`));


### PR DESCRIPTION
Com o intuito de melhorar a organização do código e evitar repetições, neste caso nos resolvers, essa PR cria uma pasta separando o context do Apollo Server.

Dessa forma, o context vira uma função separada em uma pasta a parte. 